### PR TITLE
Added Racket and Guile Scheme, improved efficiency of C++ and Haskell examples.

### DIFF
--- a/cpp/cpp.cpp
+++ b/cpp/cpp.cpp
@@ -1,15 +1,16 @@
 // build with: clang++ -std=c++11 -o squid cpp.cpp
 #include <iostream>
-#include <algorithm>
 #include <vector>
 
 int main(int argc, char** argv)
 {
-    std::vector<std::string> you = {"k", "squ"};
-    while (true) {
-        for_each(you.begin(), you.end(), [](std::string x) {
-            std::cout << "You're a " << x << "id now!" << std::endl;
-        });
+  std::vector<std::string> you = {"k", "squ"};
+  
+  while (true) {
+    for(auto& s: you) {
+      std::cout << "You're a " << s << "id now!" << std::endl;
     }
-    return 0;
+  }   
+  
+  return 0;
 }

--- a/haskell/haskell.hs
+++ b/haskell/haskell.hs
@@ -1,8 +1,5 @@
-import Control.Monad
-a = ["squ", "k"]
-main = do
-  forM_ a $ \s -> do
-    putStr("You're a ")
-    putStr(s)
-    putStrLn("id now!")
-  main
+import Text.Printf
+
+main :: IO ()
+main = mapM_ (printf "You're a %sid now\n") $
+       map head $ iterate reverse ["k", "squ"]

--- a/haskell/haskell.hs
+++ b/haskell/haskell.hs
@@ -1,5 +1,5 @@
 import Text.Printf
 
 main :: IO ()
-main = mapM_ (printf "You're a %sid now\n") $
+main = mapM_ (printf "You're a %sid now!\n") $
        map head $ iterate reverse ["k", "squ"]

--- a/racket/racket.rkt
+++ b/racket/racket.rkt
@@ -1,0 +1,7 @@
+#lang racket
+
+(define (squidkid)
+  (map (λ (sub) (display (format "You're a ~aid now!~%" sub))) '("k" "squ"))
+  (squidkid))
+
+(squidkid)

--- a/scheme/scheme.scm
+++ b/scheme/scheme.scm
@@ -1,0 +1,3 @@
+(while #t ; Implementation: Guile
+       (map (λ (sub) (format #t "You're a ~aid now!~%" sub))
+            '("k" "squ")))


### PR DESCRIPTION
Added Racket and Guile Scheme language examples.

----

Made small improvements to the C++ example to bring it closer to idealized "Modern C++", taking advantage of new features such as type deduction and the improved "range-based for" syntax.

Tested with clang and gcc with the C++11 standard flag.

----

Changed Haskell example to avoid "do" syntax and better represent idiomatic Haskell.